### PR TITLE
Add support for generating mermaid diagrams

### DIFF
--- a/examples/generate.rb
+++ b/examples/generate.rb
@@ -3,6 +3,7 @@ require "bundler/setup"
 
 require "active_record"
 require "rails_erd/diagram/graphviz"
+require "rails_erd/diagram/mermaid"
 require "active_support/dependencies"
 
 output_dir = File.expand_path("output", ".")
@@ -44,9 +45,17 @@ Dir["#{File.dirname(__FILE__)}/*/*"].each do |path|
         # Generate ERD.
         outfile = RailsERD::Diagram::Graphviz.new(domain, default_options.merge(specific_options)).create
 
-        puts "   - #{notation} notation saved to #{outfile}"
+        puts "   - Graphviz #{notation} notation saved to #{outfile}"
       end
     end
+
+    filename = File.expand_path("#{output_dir}/#{name}", File.dirname(__FILE__))
+    default_options = { :filetype => "txt", :filename => filename }      
+    specific_options = eval((File.read("#{path}/options.rb") rescue "")) || {}
+    
+    outfile = RailsERD::Diagram::Mermaid.new(domain, default_options.merge(specific_options)).create
+    puts "   - Mermaid saved to #{outfile}"
+    
     puts
   ensure
     # Completely remove all loaded Active Record models.

--- a/lib/rails_erd.rb
+++ b/lib/rails_erd.rb
@@ -36,6 +36,7 @@ module RailsERD
 
     def default_options
       ActiveSupport::OrderedOptions[
+        :generator, "graphviz",
         :attributes, :content,
         :disconnected, true,
         :filename, "erd",

--- a/lib/rails_erd/cli.rb
+++ b/lib/rails_erd/cli.rb
@@ -1,10 +1,15 @@
 require "rails_erd"
 require "choice"
 
-Choice.options do
+Choice.options do  
   separator ""
   separator "Diagram options:"
 
+  option :engine do
+    long "--engine=ENGINE"
+    desc "Engine to use (graphviz or mermaid). Defaults to graphviz."
+  end
+  
   option :title do
     long "--title=TITLE"
     desc "Replace default diagram title with a custom one."
@@ -158,8 +163,8 @@ module RailsERD
     end
 
     def initialize(path, options)
-      @path, @options = path, options
-      require "rails_erd/diagram/graphviz"
+      @path, @options = path, options      
+      require "rails_erd/diagram/graphviz" if options.generator != :mermaid
     end
 
     def start
@@ -188,9 +193,18 @@ module RailsERD
     rescue TypeError
     end
 
+    def generator
+      if options.generator == :mermaid
+        RailsERD::Diagram::Mermaid
+      else
+        RailsERD::Diagram::Graphviz
+      end
+    end
+
     def create_diagram
       $stderr.puts "Generating entity-relationship diagram for #{ActiveRecord::Base.descendants.length} models..."
-      file = RailsERD::Diagram::Graphviz.create(options)
+
+      file = generator.create(options)
       $stderr.puts "Diagram saved to '#{file}'."
       `open #{file}` if options[:open]
     end

--- a/lib/rails_erd/diagram/mermaid.rb
+++ b/lib/rails_erd/diagram/mermaid.rb
@@ -1,0 +1,65 @@
+require "rails_erd/diagram"
+#require "erb"
+
+module RailsERD
+  class Diagram
+    class Mermaid < Diagram
+
+      attr_accessor :graph
+
+      setup do
+        self.graph = ["classDiagram"]
+
+        # hard code to RL to make it easier to view diagrams from GitHub
+        self.graph << "\tdirection RL"
+      end
+
+      each_entity do |entity, attributes|
+        graph << "\tclass `#{entity}`"
+
+        attributes.each do | attr|
+          graph << "\t`#{entity}` : +#{attr.type} #{attr.name}"
+        end
+      end
+
+      each_specialization do |specialization|
+        from, to = specialization.generalized, specialization.specialized
+        graph << "\t<<polymorphic>> `#{specialization.generalized}`"
+        graph << "\t #{from.name} <|-- #{to.name}"
+      end
+
+      each_relationship do |relationship|
+        from, to = relationship.source, relationship.destination        
+        graph << "\t`#{from.name}` #{relation_arrow(relationship)} `#{to.name}`"
+
+        from.children.each do |child|
+          graph << "\t`#{child.name}` #{relation_arrow(relationship)} `#{to.name}`"
+        end
+        
+        to.children.each do |child|
+          graph << "\t`#{from.name}` #{relation_arrow(relationship)} `#{child.name}`"
+        end
+      end
+
+      save do
+        raise "Saving diagram failed!\nOutput directory '#{File.dirname(filename)}' does not exist." unless File.directory?(File.dirname(filename))
+
+        File.write(filename.gsub(/\s/,"_"), graph.uniq.join("\n"))
+        filename
+      end
+
+      def filename
+        "#{options.filename}.mmd"
+      end
+
+      def relation_arrow(relationship)
+        arrow_body = relationship.indirect? ? ".." : "--"
+        arrow_head = relationship.to_many? ?  ">" : ""
+        arrow_tail = relationship.many_to? ? "<" : ""
+
+        "#{arrow_tail}#{arrow_body}#{arrow_head}"
+      end
+      
+    end
+  end
+end

--- a/lib/rails_erd/tasks.rake
+++ b/lib/rails_erd/tasks.rake
@@ -5,7 +5,7 @@ def say(message)
 end
 
 namespace :erd do
-  task :check_dependencies do
+  task :check_dependencies do    
     include GraphViz::Utils
     unless find_executable("dot", nil)
       raise "Unable to find GraphViz's \"dot\" executable. Please " \
@@ -54,11 +54,16 @@ namespace :erd do
     raise "Active Record was not loaded." unless defined? ActiveRecord
   end
 
-  task :generate => [:check_dependencies, :options, :load_models] do
+  task :generate => [:options, :check_dependencies, :load_models] do
     say "Generating Entity-Relationship Diagram for #{ActiveRecord::Base.descendants.length} models..."
 
-    require "rails_erd/diagram/graphviz"
-    file = RailsERD::Diagram::Graphviz.create
+    file = nil
+    if RailsERD.options.generator == :mermaid
+      file = RailsERD::Diagram::Mermaid.create
+    else
+      require "rails_erd/diagram/graphviz"
+      file = RailsERD::Diagram::Graphviz.create
+    end
 
     say "Done! Saved diagram to #{file}."
   end

--- a/test/unit/mermaid_test.rb
+++ b/test/unit/mermaid_test.rb
@@ -1,0 +1,283 @@
+require File.expand_path("../test_helper", File.dirname(__FILE__))
+require "rails_erd/diagram/mermaid"
+
+class MermaidTest < ActiveSupport::TestCase
+  def setup
+    RailsERD.options.filetype = :png
+    RailsERD.options.warn     = false
+  end
+
+  def teardown
+    FileUtils.rm Dir["erd*.*"] rescue nil
+  end
+
+  def diagram(options = {})
+    @diagram ||= Diagram::Mermaid.new(Domain.generate(options), options).tap do |diagram|
+      diagram.generate
+    end
+  end
+
+  def find_dot_nodes(diagram)
+    [].tap do |nodes|
+      diagram.graph.each_node do |name, node|
+        nodes << node
+      end
+    end
+  end
+  
+  # Diagram properties =======================================================
+  test "file name should be mmd" do
+    create_simple_domain
+    begin
+      assert_equal "erd.mmd", Diagram::Mermaid.create
+    ensure
+      FileUtils.rm "erd.mmd" rescue nil
+    end
+  end
+
+  test "direction should be right to left" do
+    create_simple_domain
+
+    assert_equal "\tdirection RL", diagram.graph[1]
+  end
+
+
+  # # Diagram generation =======================================================
+  test "create should create output for domain with attributes" do
+    create_model "Foo", :bar => :references, :column => :string do
+      belongs_to :bar
+    end
+
+    create_model "Bar", :column => :string
+
+    expected = [
+      "classDiagram",
+      "\tdirection RL",
+      "\tclass `Bar`",
+      "\t`Bar` : +string column",
+      "\tclass `Foo`",
+      "\t`Foo` : +string column",
+      "\t`Bar` --> `Foo`"
+    ]
+
+    assert_equal expected, diagram.graph
+  end
+
+  test "create should create output for domain without attributes" do
+    create_simple_domain
+
+    expected = [
+      "classDiagram",
+      "\tdirection RL",
+      "\tclass `Bar`",
+      "\tclass `Beer`",
+      "\t`Bar` --> `Beer`"
+    ]
+    
+    assert_equal expected, diagram.graph
+  end
+
+  test "create should abort and complain if there are no connected models" do
+    message = nil
+    begin
+      Diagram::Mermaid.create
+    rescue => e
+      message = e.message
+    end
+    assert_match(/No entities found/, message)
+  end
+
+  test "create should abort and complain if output directory does not exist" do
+    message = nil
+
+    begin
+      create_simple_domain
+      Diagram::Mermaid.create(:filename => "does_not_exist/foo")
+    rescue => e
+      message = e.message
+    end
+
+    assert_match(/Output directory 'does_not_exist' does not exist/, message)
+  end
+
+  test "generate should add attributes to entity" do
+    RailsERD.options.markup = false
+    create_model "Foo", :bar => :references do
+      belongs_to :bar
+    end
+    create_model "Bar", :column => :string, :column_two => :boolean
+
+    expected = [
+      "classDiagram",
+      "\tdirection RL",
+      "\tclass `Bar`",
+      "\t`Bar` : +string column",
+      "\t`Bar` : +boolean column_two",
+      "\tclass `Foo`",
+      "\t`Bar` --> `Foo`"
+    ]
+          
+    assert_equal expected, diagram.graph
+  end
+
+  test "generate should not add any attributes if attributes is set to false" do
+    create_model "Jar", :contents => :string
+    create_model "Lid", :jar => :references do
+      belongs_to :jar
+    end
+
+    expected = [
+      "classDiagram",
+      "\tdirection RL",
+      "\tclass `Jar`",
+      "\tclass `Lid`",
+      "\t`Jar` --> `Lid`"
+    ]
+    
+    assert_equal expected, diagram(:attributes => false).graph
+  end
+
+  test "generate should create edge to polymorphic entity if polymorphism is true" do
+    create_model "Cannon", :defensible => :references do
+      belongs_to :defensible, :polymorphic => true
+    end
+
+    create_model "Stronghold" do
+      has_many :cannons, :as => :defensible
+    end
+
+    create_model "Galleon" do
+      has_many :cannons, :as => :defensible
+    end
+
+    expected = [
+      "classDiagram",
+      "\tdirection RL",
+      "\tclass `Cannon`",
+      "\tclass `Defensible`",
+      "\tclass `Galleon`",
+      "\tclass `Stronghold`",
+      "\t<<polymorphic>> `Defensible`",
+      "\t Defensible <|-- Galleon",
+      "\t Defensible <|-- Stronghold",
+      "\t`Defensible` --> `Cannon`",
+      "\t`Galleon` --> `Cannon`",
+      "\t`Stronghold` --> `Cannon`"
+    ]
+    
+    assert_equal expected, diagram(:polymorphism => true).graph.uniq
+  end
+
+  test "generate should create edge to each child of polymorphic entity if polymorphism is false" do
+    create_model "Cannon", :defensible => :references do
+      belongs_to :defensible, :polymorphic => true
+    end
+
+    create_model "Stronghold" do
+      has_many :cannons, :as => :defensible
+    end
+    
+    create_model "Galleon" do
+      has_many :cannons, :as => :defensible
+    end
+
+    expected = [
+      "classDiagram",
+      "\tdirection RL",
+      "\tclass `Cannon`",
+      "\tclass `Galleon`",
+      "\tclass `Stronghold`",
+      "\t`Defensible` --> `Cannon`",
+      "\t`Galleon` --> `Cannon`",
+      "\t`Stronghold` --> `Cannon`"
+    ]
+    assert_equal expected, diagram.graph.uniq
+  end
+
+  test "generate should support one to many relationships" do
+    create_one_to_many_assoc_domain
+
+    expected = [
+      "classDiagram",
+      "\tdirection RL",
+      "\tclass `Many`",
+      "\tclass `One`",
+      "\t`One` --> `Many`"
+    ]
+    
+    assert_equal expected, diagram.graph.uniq
+  end
+
+  test "generate should support one to many indirect relationships" do
+    create_model "Foo" do
+      has_many :bazs
+      has_many :bars
+    end
+    
+    create_model "Bar", :foo => :references do
+      belongs_to :foo
+      has_many :bazs, :through => :foo
+    end
+    
+    create_model "Baz", :foo => :references do
+      belongs_to :foo
+    end
+
+    expected = [
+      "classDiagram",
+      "\tdirection RL",
+      "\tclass `Bar`",
+      "\tclass `Baz`",
+      "\tclass `Foo`",
+      "\t`Foo` --> `Baz`",
+      "\t`Foo` --> `Bar`",
+      "\t`Bar` ..> `Baz`"
+    ]
+    
+    assert_equal expected, diagram.graph.uniq
+  end
+
+  test "generate should support many to many relationships" do
+    create_many_to_many_assoc_domain
+
+    expected = [
+      "classDiagram",
+      "\tdirection RL",
+      "\tclass `Many`",
+      "\tclass `More`",
+      "\t`Many` <--> `More`"
+    ]
+    
+    assert_equal expected, diagram.graph.uniq
+  end
+  
+  test "generate should support one to one relationships" do
+    create_one_to_one_assoc_domain
+
+    expected = [
+      "classDiagram",
+      "\tdirection RL",
+      "\tclass `One`",
+      "\tclass `Other`",
+      "\t`One` -- `Other`"
+    ]
+    
+    assert_equal expected, diagram.graph.uniq
+  end
+
+  test "generate should support one to one recursive relationships" do
+    create_model "Emperor" do
+      belongs_to :predecessor, :class_name => "Emperor"
+      has_one :successor, :class_name => "Emperor", :foreign_key => :predecessor_id
+    end
+
+    expected = [
+      "classDiagram",
+      "\tdirection RL",
+      "\tclass `Emperor`",
+      "\t`Emperor` -- `Emperor`"
+    ]
+
+    assert_equal expected, diagram.graph.uniq
+  end
+end

--- a/test/unit/rake_task_test.rb
+++ b/test/unit/rake_task_test.rb
@@ -1,4 +1,6 @@
 require File.expand_path("../test_helper", File.dirname(__FILE__))
+require "rails_erd/diagram/graphviz"
+require "rails_erd/diagram/mermaid"
 
 class RakeTaskTest < ActiveSupport::TestCase
   include ActiveSupport::Testing::Isolation
@@ -32,13 +34,24 @@ class RakeTaskTest < ActiveSupport::TestCase
   end
 
   # Diagram generation =======================================================
-  test "generate task should create output based on domain model" do
+  test "generate task should create output based on domain model with graphviz by default" do
     create_simple_domain
 
-    Diagram.any_instance.expects(:save)
+    RailsERD::Diagram::Graphviz.any_instance.expects(:save)
+    Rake::Task["erd:options"].execute
     Rake::Task["erd:generate"].execute
   end
 
+  test "generate task should create output based on domain model with mermaid if specified" do
+    create_simple_domain
+
+    ENV["generator"] = "mermaid"
+    RailsERD::Diagram::Mermaid.any_instance.expects(:save)
+    Rake::Task["erd:options"].execute
+    Rake::Task["erd:generate"].execute
+  end
+
+  
   test "generate task should not create output if there are no connected models" do
     Rake::Task["erd:generate"].execute rescue nil
     assert !File.exist?("erd.dot")
@@ -184,6 +197,13 @@ Error occurred while loading application: FooBar (RuntimeError)
     ENV["only_recursion_depth"] = "test"
     Rake::Task["erd:options"].execute
     assert_equal :test, RailsERD.options.only_recursion_depth
+  end
+
+
+  test "options task sets generator type" do
+    ENV["generator"] = "mermaid"
+    Rake::Task["erd:options"].execute
+    assert_equal :mermaid, RailsERD.options.generator
   end
 
   test "options task should set single parameter to only as array xxx" do


### PR DESCRIPTION
This PR adds support for generating diagrams using [mermaid](https://mermaid-js.github.io/mermaid/).

Here is an example output for the [Event Forms](https://github.com/krames/rails-erd/tree/master/examples/applications/event_forms) sample schema.

```mermaid
classDiagram
	direction RL
	class `ActiveRecord::InternalMetadata`
	`ActiveRecord::InternalMetadata` : +string value
	class `ActiveRecord::SchemaMigration`
	class `Event`
	`Event` : +boolean active
	`Event` : +string costs
	`Event` : +text description
	`Event` : +string duration
	`Event` : +text introduction
	`Event` : +text report
	`Event` : +string speaker
	`Event` : +string target_audience
	`Event` : +string title
	`Event` : +string tutors
	class `EventDate`
	`EventDate` : +string date
	`EventDate` : +text description
	`EventDate` : +date expiry_date
	`EventDate` : +string location
	class `Form`
	`Form` : +string name
	class `FormField`
	`FormField` : +string field_type
	`FormField` : +string label
	`FormField` : +boolean mandatory
	`FormField` : +string name
	class `FormFieldValue`
	`FormFieldValue` : +string key
	`FormFieldValue` : +string value
	class `Group`
	`Group` : +boolean active
	`Group` : +text description
	`Group` : +text email_message
	`Group` : +string email_receiver
	`Group` : +string email_subject
	`Group` : +string title
	`Group` : +string url_slug
	class `Organization`
	`Organization` : +string domain
	`Organization` : +text email_message
	`Organization` : +string email_receiver
	`Organization` : +string email_subject
	`Organization` : +string name
	`Organization` : +string phone
	`Organization` : +string signup_title
	`Organization` : +string subdomain
	`Organization` : +string website
	class `Signup`
	`Signup` : +boolean confirmed
	`Signup` : +string email
	`Signup` : +text serialized_fields
	class `Stylesheet`
	`Stylesheet` : +text content
	`Stylesheet` : +string name
	`FormField` --> `FormFieldValue`
	`Event` --> `EventDate`
	`EventDate` --> `Signup`
	`Organization` --> `Stylesheet`
	`Stylesheet` --> `Group`
	`Organization` --> `Group`
	`Form` --> `Group`
	`Group` --> `Event`
	`Group` ..> `EventDate`
	`Organization` --> `Form`
	`Form` --> `FormField`
	`Organization` ..> `Event`
```

Mermaid generation can be configured by adding `generator=mermaid` parameter when invoking rake task or specifying the generator in configuration file to be mermaid.